### PR TITLE
Add access to I2C_SLAVE_FORCE

### DIFF
--- a/Adafruit_PureIO/smbus.py
+++ b/Adafruit_PureIO/smbus.py
@@ -86,13 +86,14 @@ class SMBus(object):
     pure Python calls to ioctl and direct /dev/i2c device access.
     """
 
-    def __init__(self, bus=None):
+    def __init__(self, bus=None, dangerous=False):
         """Create a new smbus instance.  Bus is an optional parameter that
         specifies the I2C bus number to use, for example 1 would use device
         /dev/i2c-1.  If bus is not specified then the open function should be
         called to open the bus.
         """
         self._device = None
+        self._dangerous = dangerous
         if bus is not None:
             self.open(bus)
 
@@ -132,7 +133,10 @@ class SMBus(object):
 
     def _select_device(self, addr):
         """Set the address of the device to communicate with on the I2C bus."""
-        ioctl(self._device.fileno(), I2C_SLAVE, addr & 0x7F)
+        if self._dangerous:
+            ioctl(self._device.fileno(), I2C_SLAVE_FORCE, addr & 0x7F)
+        else:
+            ioctl(self._device.fileno(), I2C_SLAVE, addr & 0x7F)
 
     def read_byte(self, addr):
         """Read a single byte from the specified device."""

--- a/Adafruit_PureIO/smbus.py
+++ b/Adafruit_PureIO/smbus.py
@@ -91,11 +91,13 @@ class SMBus(object):
         specifies the I2C bus number to use, for example 1 would use device
         /dev/i2c-1.  If bus is not specified then the open function should be
         called to open the bus.
+        When the dangerous flag is set to true, it forces access to devices
+        that are owned by the kernel.  This is ...  well ... dangerous.
         """
         self._device = None
         self._dangerous = dangerous
         if bus is not None:
-            self.open(bus)
+            self.open(bus, dangerous)
 
     def __del__(self):
         """Clean up any resources used by the SMBus instance."""
@@ -113,11 +115,14 @@ class SMBus(object):
         self.close()
         return False  # Don't suppress exceptions.
 
-    def open(self, bus):
-        """Open the smbus interface on the specified bus."""
+    def open(self, bus, dangerous=False):
+        """Open the smbus interface on the specified bus.
+        When the dangerous flag is set to true, it forces access to devices
+        that are owned by the kernel.  This is ...  well ... dangerous."""
         # Close the device if it's already open.
         if self._device is not None:
             self.close()
+        self._dangerous = dangerous
         # Try to open the file for the specified bus.  Must turn off buffering
         # or else Python 3 fails (see: https://bugs.python.org/issue20074)
         self._device = open('/dev/i2c-{0}'.format(bus), 'r+b', buffering=0)

--- a/tests/test_chip.py
+++ b/tests/test_chip.py
@@ -1,0 +1,72 @@
+# Interactive basic test for Adafruit_PureIO.smbus module.
+# Intended to be run on NTC's C.H.I.P. single-board computer.
+#   (see https://getchip.com).
+# Instructions:
+#   sudo python test_chip.py
+
+import Adafruit_PureIO.smbus as smbus
+
+AXP209_DEV_BUS = 0  # I2C bus for AXP209 power controller chip
+AXP209_DEV_ADDR = 0x34  # I2C address for AXP209 power controller chip
+STATUS_LED_REG = 0x93  # AXP209 register for GPIO2, drives status LED
+RESET_REG = 0x4a  # AXP209 register containing reset status bits
+SHORT_PRESS_MASK = 0x02  # bit of RESET_REG indicating a short reset
+
+a = raw_input("Status LED should be on.  (y/n): ")
+assert(a.upper() == "Y")
+
+bus = smbus.SMBus(AXP209_DEV_BUS, dangerous=True)
+bus.write_byte_data(AXP209_DEV_ADDR, STATUS_LED_REG, 0)
+bus.close()
+
+a = raw_input("Status LED should now be off.  (y/n): ")
+assert(a.upper() == "Y")
+
+# read the "short press" status bit:
+
+bus = smbus.SMBus()
+bus.open(AXP209_DEV_BUS, dangerous=True)
+reset_reg = bus.read_byte_data(AXP209_DEV_ADDR, RESET_REG)
+short_press = ((reset_reg & SHORT_PRESS_MASK) == SHORT_PRESS_MASK)
+assert(not short_press)
+bus.close()
+
+a = raw_input("BRIEFLY press the reset button, then press enter: ")
+
+bus = smbus.SMBus(AXP209_DEV_BUS, dangerous=True)
+bus.open(AXP209_DEV_BUS, dangerous=True)  # should work to re-open it
+reset_reg = bus.read_byte_data(AXP209_DEV_ADDR, RESET_REG)
+short_press = ((reset_reg & SHORT_PRESS_MASK) == SHORT_PRESS_MASK)
+assert(short_press)
+
+# Clear the "short press" bit.
+bus.write_byte_data(AXP209_DEV_ADDR, RESET_REG, 2)
+reset_reg = bus.read_byte_data(AXP209_DEV_ADDR, RESET_REG)
+short_press = ((reset_reg & SHORT_PRESS_MASK) == SHORT_PRESS_MASK)
+assert(not short_press)
+bus.close()
+
+# Make sure non-dangerous mode throws exception.
+
+bus = smbus.SMBus(AXP209_DEV_BUS)
+err = None
+try:
+    bus.write_byte_data(AXP209_DEV_ADDR, STATUS_LED_REG, 1)
+except IOError, e:
+    err = e.errno
+assert(err == 16)
+bus.close()
+
+a = raw_input("Status LED should still be off.  (y/n): ")
+assert(a.upper() == "Y")
+
+# Leave status LED on.
+
+bus = smbus.SMBus(AXP209_DEV_BUS, dangerous=True)
+bus.write_byte_data(AXP209_DEV_ADDR, STATUS_LED_REG, 1)
+bus.close()
+
+a = raw_input("Status LED should now be on.  (y/n): ")
+assert(a.upper() == "Y")
+
+print "All tests successful!"


### PR DESCRIPTION
Hello.  Thank you very much for writing this library!  I hope you accept this pull request.

Short version: I added an optional parameter to __init__() and open() to tell the device select function to use "I2C_SLAVE_FORCE" instead of "I2C_SLAVE".  Existing code should be unaffected.  Test code is included.

Long version:

I have a C.H.I.P board (see https://getchip.com) and wanted to be able to access the power controller (AXP209) on bus 0.  However, this library, and the original smbus library it was based on, says that the device is busy.  This is presumably because the kernel is using it.

Imagine my surprise when the i2c command-line tools are able to access it just fine.  A bit of research shows why: i2c command-line tools use I2C_SLAVE_FORCE, while the libraries use "I2C_SLAVE".

I can understand why the library would not use _FORCE: it is dangerous.  The kernel keeps track of the state of the device, and if you change that state out from under the kernel, bad things can happen, up to and including panicking the kernel.

I can also understand why the i2c tools use _FORCE: if an administrator, who presumably knows what he is doing, needs to diddle something, he needs a tool to do it.  Fortunately, the administrator needs root access to do it.

But so does a python programmer.  I.e. adding the ability to use _FORCE with this library doesn't make the overall system any more vulnerable or dangerous.  Since python is a widely-used language by administrators, I think the library should grant the same access as the command-line tools.

So I added the "dangerous" flag to both __init__() and open().  :-)  It is an optional parameter, so existing code should not be affected.  I called it "dangerous" instead of "force" because in the future we may find other restrictions which are generally a good idea to enforce, but want a bypass for those who like to live on the edge.

Since I don't have an RPi, I couldn't run the test code.  So I wrote an additional test program which works on C.H.I.P.  That program demonstrates its use.

Steve
