### PR TITLE
allow multibyte write-then-read 

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,7 +6,7 @@ python:
 - '3.6'
 install:
 - pip install -r requirements.txt
-- pip install pylint
+- pip install --force-reinstall pylint==1.9.2
 script:
 - pylint Adafruit_PureIO/smbus.py
 deploy:

--- a/Adafruit_PureIO/smbus.py
+++ b/Adafruit_PureIO/smbus.py
@@ -88,8 +88,10 @@ def make_i2c_rdwr_data(messages):
     data.nmsgs = len(messages)
     return data
 
+# pylint: disable=bad-option-value
+
 # Create an interface that mimics the Python SMBus API.
-class SMBus(object): # pylint: disable=useless-object-inheritance, bad-option-value
+class SMBus(object): # pylint: disable=useless-object-inheritance
     """I2C interface that mimics the Python SMBus API but is implemented with
     pure Python calls to ioctl and direct /dev/i2c device access.
     """

--- a/Adafruit_PureIO/smbus.py
+++ b/Adafruit_PureIO/smbus.py
@@ -210,17 +210,17 @@ class SMBus(object): # pylint: disable=useless-object-inheritance
             reg = cmd  # backup
             cmd = bytearray(1)
             cmd[0] = reg
-            
+
         cmdstring = create_string_buffer(len(cmd))
-        for i in range(len(cmd)):
-            cmdstring[i] = cmd[i]
+        for i, val in enumerate(cmd):
+            cmdstring[i] = val
 
         result = create_string_buffer(length)
-        
+
         # Build ioctl request.
         request = make_i2c_rdwr_data([
-            (addr, 0,        len(cmd), cast(cmdstring, POINTER(c_uint8))),             # Write cmd register.
-            (addr, I2C_M_RD, length,   cast(result, POINTER(c_uint8)))   # Read data.
+            (addr, 0, len(cmd), cast(cmdstring, POINTER(c_uint8))),    # Write cmd register.
+            (addr, I2C_M_RD, length, cast(result, POINTER(c_uint8)))   # Read data.
             ])
 
         # Make ioctl call and return result data.

--- a/Adafruit_PureIO/smbus.py
+++ b/Adafruit_PureIO/smbus.py
@@ -204,13 +204,25 @@ class SMBus(object): # pylint: disable=useless-object-inheritance
         """
         assert self._device is not None, 'Bus must be opened before operations are made against it!'
         # Build ctypes values to marshall between ioctl and Python.
-        reg = c_uint8(cmd)
+
+        # convert register into bytearray
+        if not isinstance(cmd, (bytes, bytearray)):
+            reg = cmd  # backup
+            cmd = bytearray(1)
+            cmd[0] = reg
+            
+        cmdstring = create_string_buffer(len(cmd))
+        for i in range(len(cmd)):
+            cmdstring[i] = cmd[i]
+
         result = create_string_buffer(length)
+        
         # Build ioctl request.
         request = make_i2c_rdwr_data([
-            (addr, 0, 1, pointer(reg)),             # Write cmd register.
-            (addr, I2C_M_RD, length, cast(result, POINTER(c_uint8)))   # Read data.
-        ])
+            (addr, 0,        len(cmd), cast(cmdstring, POINTER(c_uint8))),             # Write cmd register.
+            (addr, I2C_M_RD, length,   cast(result, POINTER(c_uint8)))   # Read data.
+            ])
+
         # Make ioctl call and return result data.
         ioctl(self._device.fileno(), I2C_RDWR, request)
         return bytearray(result.raw)  # Use .raw instead of .value which will stop at a null byte!

--- a/Adafruit_PureIO/smbus.py
+++ b/Adafruit_PureIO/smbus.py
@@ -88,10 +88,8 @@ def make_i2c_rdwr_data(messages):
     data.nmsgs = len(messages)
     return data
 
-# pylint: disable=bad-option-value
-
 # Create an interface that mimics the Python SMBus API.
-class SMBus(object): # pylint: disable=useless-object-inheritance
+class SMBus(object):
     """I2C interface that mimics the Python SMBus API but is implemented with
     pure Python calls to ioctl and direct /dev/i2c device access.
     """

--- a/Adafruit_PureIO/smbus.py
+++ b/Adafruit_PureIO/smbus.py
@@ -89,7 +89,7 @@ def make_i2c_rdwr_data(messages):
     return data
 
 # Create an interface that mimics the Python SMBus API.
-class SMBus(object): # pylint: disable=useless-object-inheritance
+class SMBus(object): # pylint: disable=useless-object-inheritance, bad-option-value
     """I2C interface that mimics the Python SMBus API but is implemented with
     pure Python calls to ioctl and direct /dev/i2c device access.
     """


### PR DESCRIPTION
is backcompatible if you pass in a byte instead of a bytearray
