### PR TITLE
Make Python 3.9 compatible

### DIFF
--- a/Adafruit_PureIO/spi.py
+++ b/Adafruit_PureIO/spi.py
@@ -357,7 +357,7 @@ class SPI:
     def writebytes(self, data, max_speed_hz=0, bits_per_word=0, delay=0):
         """Perform half-duplex SPI write.
         """
-        data = array.array("B", data).tostring()
+        data = array.array("B", data).tobytes()
         # length = len(data)
         chunks = [
             data[i : i + self.chunk_size] for i in range(0, len(data), self.chunk_size)
@@ -408,7 +408,7 @@ class SPI:
     def transfer(self, data, max_speed_hz=0, bits_per_word=0, delay=0):
         """Perform full-duplex SPI transfer
         """
-        data = array.array("B", data).tostring()
+        data = array.array("B", data).tobytes()
         receive_data = []
 
         chunks = [


### PR DESCRIPTION
Fixes #21. Tested on Python 3.7 and 3.9. This change should work as far back as 3.2 according to the documentation.