### PR TITLE
Adding missing attribution for SPI code

### DIFF
--- a/Adafruit_PureIO/spi.py
+++ b/Adafruit_PureIO/spi.py
@@ -25,9 +25,9 @@
 ================================================================================
 
 Pure python (i.e. no native extensions) access to Linux IO SPI interface that is
-similar to the SpiDev API.
+similar to the SpiDev API. Based heavily on https://github.com/tomstokes/python-spi/.
 
-* Author(s): Melissa LeBlanc-Williams
+* Author(s): Tom Stokes, Melissa LeBlanc-Williams
 
 Implementation Notes
 --------------------


### PR DESCRIPTION
When I added the SPI code, I based it off of some existing work. It seems I failed to attribute it to the original author. This PR is to correct that.
